### PR TITLE
fix Mib generation: Only add readable columns to tables

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
     <PropertyGroup>
-        <AssemblyVersion>1.1.0</AssemblyVersion>
-        <FileVersion>1.1.0</FileVersion>
-        <InformationalVersion>1.1.0</InformationalVersion>
-        <Version>$(AssemblyVersion)-wmo2</Version>
+        <AssemblyVersion>1.1.1</AssemblyVersion>
+        <FileVersion>1.1.1</FileVersion>
+        <InformationalVersion>1.1.1</InformationalVersion>
+        <Version>$(AssemblyVersion)-wmo1</Version>
     </PropertyGroup>
 </Project>

--- a/Mib/Ast/Ast.cs
+++ b/Mib/Ast/Ast.cs
@@ -12,6 +12,33 @@ namespace SnmpSharpNet.Mib.Ast;
 
 using Import = (IReadOnlyList<TextSpan> symbols, TextSpan fromModule);
 
+
+public enum SMIv2Status
+{
+    Current,
+    Obsolete,
+    Deprecated
+}
+
+public enum SMIv2Accessibility
+{
+    NotAccessible,
+    AccessibleForNotify,
+    ReadOnly,
+    ReadWrite,
+    ReadCreate
+}
+
+public static class SMIv2AccessibilityExtensions
+{
+    extension(SMIv2Accessibility accessibility)
+    {
+        public bool CanRead() =>
+            accessibility >= SMIv2Accessibility.ReadOnly;
+    }
+}
+
+
 // Common helpers for ASN.1 / Structure of Management Information Version 2
 // See https://www.rfc-editor.org/rfc/rfc2578.html
 public static class SMIv2 {
@@ -71,12 +98,23 @@ public static class SMIv2 {
             .SkipAnd(AstType.Parser.ElseError("Expected type after SYNTAX"))
             .WithName("OTSyntaxPart");
 
-    // This is simply ignored
-    // OTMaxAccessPart = "MAX-ACCESS" <string>
-    public static readonly Parser<TextSpan> OTMaxAccessPart =
+    // OTMaxAccessPart = "MAX-ACCESS" AccessSpecifier
+    // AccessSpecifier = "not-accessible"
+    //                 | "accessible-for-notify"
+    //                 | "read-only"
+    //                 | "read-write"
+    //                 | "read-create"
+    public static readonly Parser<SMIv2Accessibility> OTMaxAccessPart =
         Terms.Keyword("MAX-ACCESS")
-            .SkipAnd(Ident)
-            .WithName("OTMaxAccessPart");
+            .SkipAnd(
+                OneOf(
+                    Terms.Keyword("not-accessible").Then(static x => SMIv2Accessibility.NotAccessible),
+                    Terms.Keyword("accessible-for-notify").Then(static x => SMIv2Accessibility.AccessibleForNotify),
+                    Terms.Keyword("read-only").Then(static x => SMIv2Accessibility.ReadOnly),
+                    Terms.Keyword("read-write").Then(static x => SMIv2Accessibility.ReadWrite),
+                    Terms.Keyword("read-create").Then(static x => SMIv2Accessibility.ReadCreate)
+                ).ElseError("Expected 'not-accessible', 'accessible-for-notify', 'read-only', 'read-write' or 'read-create' after MAX-ACCESS")
+            ).WithName("OTMaxAccessPart");
 
     // OTStatusPart = "STATUS" ("current" | "deprecated" | "obsolete")
     public static readonly Parser<SMIv2Status> OTStatusPart =
@@ -111,17 +149,17 @@ public static class SMIv2 {
             .SkipAnd(String.ElseError("Expected string after UNITS"))
             .WithName("OTUnitsPart");
 
-    // Note: Currently we only return status
+    // Note: Currently we only return max-access and status
     //  OTMiddlePart =
     //      OTUnitsPart?
     //      OTMaxAccessPart
     //      OTStatusPart
     //      OTDescriptionPart
     //      OTReferPart?
-    public static readonly Parser<SMIv2Status> OTMiddlePart =
+    public static readonly Parser<(SMIv2Accessibility, SMIv2Status)> OTMiddlePart =
         OTUnitsPart.ZeroOrOne()
-            .AndSkip(OTMaxAccessPart.ElseError("Expected 'MAX-ACCESS' in object type"))
-            .SkipAnd(OTStatusPart.ElseError("Expected 'STATUS' in object type"))
+            .SkipAnd(OTMaxAccessPart.ElseError("Expected 'MAX-ACCESS' in object type"))
+            .And(OTStatusPart.ElseError("Expected 'STATUS' in object type"))
             .AndSkip(OTDescriptionPart.ZeroOrOne())
             .AndSkip(OTReferPart.ZeroOrOne())
             .WithName("OTMiddlePart");
@@ -139,12 +177,6 @@ public class UnresolvedOid(
     public long Oid { get; } = oid;
 };
 
-public enum SMIv2Status
-{
-    Current,
-    Obsolete,
-    Deprecated
-}
 public class ModuleDefinition(
     TextSpan identifier,
     IReadOnlyList<Import> imports,
@@ -232,6 +264,17 @@ public abstract class OidAssigner(
 ) : ModuleItem {
     public TextSpan Name { get; } = name;
     public UnresolvedOid Oid { get; } = oid;
+}
+
+// Common ancestor for all OBJECT-TYPE based definitions
+public abstract class ObjectType(
+    TextSpan name,
+    UnresolvedOid oid,
+    SMIv2Accessibility accessibility,
+    SMIv2Status status
+) : OidAssigner(name, oid) {
+    public SMIv2Accessibility Accessibility { get; } = accessibility;
+    public SMIv2Status Status { get; } = status;
 }
 
 // A <EntryType> defintion in 7.1.12 "Conceptual Tables" of RFC2578
@@ -411,10 +454,10 @@ public class ConceptualTable(
     TextSpan name,
     UnresolvedOid oid,
     AstType entryType,
+    SMIv2Accessibility accessibility,
     SMIv2Status status
-) : OidAssigner(name, oid) {
+) : ObjectType(name, oid, accessibility, status) {
     public AstType EntryType { get; } = entryType;
-    public SMIv2Status Status { get; } = status;
 
     //  ConceptualTable = IDENT "OBJECT-TYPE"
     //      "SYNTAX" "SEQUENCE" "OF" <type>
@@ -430,7 +473,7 @@ public class ConceptualTable(
             .And(SMIv2.OTMiddlePart)
             .And(SMIv2.OidAssignment)
             .Then(static x => new ConceptualTable(
-                x.Item1, x.Item4, x.Item2, x.Item3))
+                x.Item1, x.Item4, x.Item2, x.Item3.Item1, x.Item3.Item2))
             .WithName("ConceptualTable");
 }
 
@@ -441,11 +484,11 @@ public class ConceptualRow(
     TextSpan name,
     UnresolvedOid oid,
     AstType entryType,
+    SMIv2Accessibility accessibility,
     SMIv2Status status,
     IReadOnlyList<TextSpan> index
-) : OidAssigner(name, oid) {
+) : ObjectType(name, oid, accessibility, status) {
     public AstType EntryType { get; } = entryType;
-    public SMIv2Status Status { get; } = status;
     public IReadOnlyList<TextSpan> Index { get; } = index;
 
     //
@@ -476,7 +519,7 @@ public class ConceptualRow(
             .And(OTIndexPart)
             .And(SMIv2.OidAssignment)
             .Then(static x => new ConceptualRow(
-                x.Item1, x.Item5, x.Item2, x.Item3, x.Item4))
+                x.Item1, x.Item5, x.Item2, x.Item3.Item1, x.Item3.Item2, x.Item4))
             .WithName("ConceptualRow");
 }
 
@@ -487,11 +530,11 @@ public class AugmentingConceptualRow(
     TextSpan name,
     UnresolvedOid oid,
     AstType entryType,
+    SMIv2Accessibility accessibility,
     SMIv2Status status,
     TextSpan augments
-) : OidAssigner(name, oid) {
+) : ObjectType(name, oid, accessibility, status) {
     public AstType EntryType { get; } = entryType;
-    public SMIv2Status Status { get; } = status;
     public TextSpan Augments { get; } = augments;
 
     // OTAugmentsPart = "AUGMENTS" "{" Entry "}"
@@ -514,7 +557,7 @@ public class AugmentingConceptualRow(
             .And(OTAugmentsPart)
             .And(SMIv2.OidAssignment)
             .Then(static x => new AugmentingConceptualRow(
-                x.Item1, x.Item5, x.Item2, x.Item3, x.Item4))
+                x.Item1, x.Item5, x.Item2, x.Item3.Item1, x.Item3.Item2, x.Item4))
             .WithName("AugmentingConceptualRow");
 }
 
@@ -523,10 +566,10 @@ public class LeafObject(
     TextSpan name,
     UnresolvedOid oid,
     AstType syntax,
+    SMIv2Accessibility accessibility,
     SMIv2Status status
-) : OidAssigner(name, oid) {
+) : ObjectType(name, oid, accessibility, status) {
     public AstType Syntax { get; } = syntax;
-    public SMIv2Status Status { get; } = status;
 
     // This is simply ignored
     // OTDefValPart = "DEFVAL" "{" "{" IDENT ("," IDENT)* "}""}"
@@ -552,7 +595,7 @@ public class LeafObject(
             .AndSkip(OTDefValPart.ZeroOrOne())
             .And(SMIv2.OidAssignment)
             .Then(static x => new LeafObject(
-                x.Item1, x.Item4, x.Item2, x.Item3))
+                x.Item1, x.Item4, x.Item2, x.Item3.Item1, x.Item3.Item2))
             .WithName("LeafObject");
 }
 

--- a/Mib/BuiltinMib.cs
+++ b/Mib/BuiltinMib.cs
@@ -38,7 +38,7 @@ public class BuiltinMib : IMibThatExports
                 var oid = kvp.Value.Item1;
                 var ident = new MibItemIdent(oid, [$"<{name}>", kvp.Key]);
                 oidByName[kvp.Key] = ident;
-                Items[ident] = new MibLeaf(ident, kvp.Value.Item2);
+                Items[ident] = new MibLeaf(ident, kvp.Value.Item2, Ast.SMIv2Accessibility.ReadOnly);
             }
         }
     }

--- a/Mib/MibItem.cs
+++ b/Mib/MibItem.cs
@@ -69,15 +69,17 @@ public class MibTable(MibItemIdent ident, MibLeaf[] index, MibLeaf[] columns) : 
     public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Index.SequenceHash(), Columns.SequenceHash());
 }
 
-public class MibLeaf(MibItemIdent ident, MibType type) : MibValuedItem(ident)
+public class MibLeaf(MibItemIdent ident, MibType type, SMIv2Accessibility accessibility) : MibValuedItem(ident)
 {
     public readonly MibType Type = type;
+    public readonly SMIv2Accessibility Accessibility = accessibility;
 
     public override bool Equals(MibItem? other)
     {
         if (other is not MibLeaf o) { return false; }
         return Ident.Equals(o.Ident)
-            && Type.Equals(o.Type);
+            && Type.Equals(o.Type)
+            && Accessibility == o.Accessibility;
     }
-    public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Type);
+    public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Type, Accessibility);
 }

--- a/Mib/MibModule.cs
+++ b/Mib/MibModule.cs
@@ -183,7 +183,7 @@ public class MibModule : IMibThatExports, IEquatable<MibModule>
         foreach (var lo in module.Items.OfType<LeafObject>())
         {
             var oid = GetOid(lo.Name.ToString());
-            Items.Add(oid, new MibLeaf(oid, ResolveType(lo.Syntax)));
+            Items.Add(oid, new MibLeaf(oid, ResolveType(lo.Syntax), lo.Accessibility));
         }
 
         foreach (var table in module.Items.OfType<ConceptualTable>())
@@ -264,7 +264,7 @@ public class MibModule : IMibThatExports, IEquatable<MibModule>
                         throw new Exception($"ConceptualTable({oid}): field '{field.name}' is not a LeafObject");
                     }
                     return col;
-                });
+                }).Where(c => c.Accessibility.CanRead());
             Items.Add(oid, new MibTable(oid, [..index], [..columns]));
         }
 

--- a/tests/SnmpSharpNet.Mib.SourceGenerator.Tests/GeneratorTests.cs
+++ b/tests/SnmpSharpNet.Mib.SourceGenerator.Tests/GeneratorTests.cs
@@ -22,11 +22,10 @@ public class SourceGeneratorIntegrationTests
         // <WESTERMO-INTERFACE-MIB>::ifRefTable: 1.3.6.1.4.1.16177.2.4.1.1
         // OID layout: ifRefTable.1.<column>.<index>
         // Index 1 and 3, but a bit mixed in the ordering
+        // Note: ifRefIndex (column 1) is not-accessible, so it won't appear in SNMP responses
         { new Oid("1.3.6.1.4.1.16177.2.4.1.1.1.5.3"), new Integer32(6) }, // ifRefifType, index 3
-        { new Oid("1.3.6.1.4.1.16177.2.4.1.1.1.1.1"), new Integer32(1) },  // ifRefIndex, index 1
         { new Oid("1.3.6.1.4.1.16177.2.4.1.1.1.2.1"), new Integer32(10) }, // ifRefifIndex, index 1
         { new Oid("1.3.6.1.4.1.16177.2.4.1.1.1.3.1"), new OctetString("eth0") }, // ifRefifName, index 1
-        { new Oid("1.3.6.1.4.1.16177.2.4.1.1.1.1.3"), new Integer32(3) },  // ifRefIndex, index 3
         { new Oid("1.3.6.1.4.1.16177.2.4.1.1.1.2.3"), new Integer32(13) }, // ifRefifIndex, index 3
         { new Oid("1.3.6.1.4.1.16177.2.4.1.1.1.4.1"), new OctetString("Ethernet 0") }, // ifRefifDescr, index 1
         { new Oid("1.3.6.1.4.1.16177.2.4.1.1.1.5.1"), new Integer32(6) }, // ifRefifType, index 1
@@ -47,7 +46,6 @@ public class SourceGeneratorIntegrationTests
 
         // Verify the table entry at index 1 contains expected values
         var entry = carrier.ifRefTable.First(x => x.indexifRefIndex == new Integer32(1));
-        await Assert.That(entry.ifRefIndex).IsEqualTo(new Integer32(1));
         await Assert.That(entry.ifRefifIndex).IsEqualTo(new Integer32(10));
         await Assert.That(entry.ifRefifName).IsEqualTo(new OctetString("eth0"));
         await Assert.That(entry.ifRefifDescr).IsEqualTo(new OctetString("Ethernet 0"));
@@ -55,7 +53,6 @@ public class SourceGeneratorIntegrationTests
 
         // Verify the table entry at index 3 contains expected values
         entry = carrier.ifRefTable.First(x => x.indexifRefIndex == new Integer32(3));
-        await Assert.That(entry.ifRefIndex).IsEqualTo(new Integer32(3));
         await Assert.That(entry.ifRefifIndex).IsEqualTo(new Integer32(13));
         await Assert.That(entry.ifRefifName).IsEqualTo(new OctetString("eth3"));
         await Assert.That(entry.ifRefifDescr).IsEqualTo(new OctetString("Ethernet 3"));


### PR DESCRIPTION
From [RFC 2578](https://www.rfc-editor.org/rfc/rfc2578.html#section-7.7):
> Objects which are both specified in the INDEX clause of a conceptual
row and also columnar objects of the same conceptual row are termed
auxiliary objects.  The MAX-ACCESS clause for auxiliary objects is
"not-accessible" [..]

The genius design of SNMP allows adding objects as columns in a table without adding them as columns! This should fix that!

We should probably also deal with status (current/obsolete/deprecated) and accessibility on scalar objects but that's for another day.